### PR TITLE
ensure variables are unset before testing

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -21,6 +21,10 @@ func TestParseSimpleConfig(t *testing.T) {
 		}
 	}
 
+	// Go 1.2 and 1.3 don't have os.Unsetenv
+	os.Setenv("NAME", "")
+	os.Setenv("LOG_PATH", "")
+
 	err := envconfig.Init(&conf)
 	equals(t, "envconfig: key NAME not found", err.Error())
 


### PR DESCRIPTION
Without this, tests fail if one variable is already set, e.g.:

```
$ export NAME=2
$ go test ./...
envconfig_test.go:25:

	exp: "envconfig: key NAME not found"

	got: "envconfig: key LOG_PATH not found"

--- FAIL: TestParseSimpleConfig (0.00s)
FAIL
FAIL	github.com/vrischmann/envconfig	0.006s
```