### PR TITLE
Support for optional structs

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -28,9 +28,9 @@ func Init(conf interface{}) error {
 	switch elem.Kind() {
 	case reflect.Ptr:
 		elem.Set(reflect.New(elem.Type().Elem()))
-		return readStruct(elem.Elem(), "")
+		return readStruct(elem.Elem(), "", false)
 	case reflect.Struct:
-		return readStruct(elem, "")
+		return readStruct(elem, "", false)
 	default:
 		return errors.New("envconfig: invalid value kind, only works on structs")
 	}
@@ -60,7 +60,7 @@ func parseTag(s string) *tag {
 	return tag
 }
 
-func readStruct(value reflect.Value, parentName string) (err error) {
+func readStruct(value reflect.Value, parentName string, optional bool) (err error) {
 	for i := 0; i < value.NumField(); i++ {
 		field := value.Field(i)
 		name := value.Type().Field(i).Name
@@ -82,9 +82,9 @@ func readStruct(value reflect.Value, parentName string) (err error) {
 			field = field.Elem()
 			goto doRead
 		case reflect.Struct:
-			err = readStruct(field, combinedName)
+			err = readStruct(field, combinedName, optional || tag.optional)
 		default:
-			err = setField(field, combinedName, tag.customName != "", tag.optional)
+			err = setField(field, combinedName, tag.customName != "", optional || tag.optional)
 		}
 
 		if err != nil {

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -236,6 +236,20 @@ func TestParseCustomNameConfig(t *testing.T) {
 	equals(t, "foobar", conf.Name)
 }
 
+func TestParseOptionalStruct(t *testing.T) {
+	var conf struct {
+		Master struct {
+			Name string
+		} `envconfig:"optional"`
+	}
+
+	os.Setenv("MASTER_NAME", "")
+
+	err := envconfig.Init(&conf)
+	ok(t, err)
+	equals(t, "", conf.Master.Name)
+}
+
 // assert fails the test if the condition is false.
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 	if !condition {


### PR DESCRIPTION
This allows one to mark a whole sub-`struct` as optional.

```go
type RedisConf struct {
	Host string
}

type MySQLConf struct {
	Host string
	DSN  string
}

type Conf struct {
	Redis RedisConf `envconfig:"optional"`
	MySQL MySQLConf `envconfig:"optional"`
}

func main() {
	var conf Conf
	if err := envconfig.Init(&conf); err != nil {
		fmt.Printf("%v\n", err)
	}
}
```