### PR TITLE
Support for prefixed config keys

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -18,6 +18,10 @@ type Unmarshaler interface {
 
 // Init reads the configuration from environment variables and populates the conf object. conf must be a pointer
 func Init(conf interface{}) error {
+	return InitWithPrefix(conf, "")
+}
+
+func InitWithPrefix(conf interface{}, prefix string) error {
 	value := reflect.ValueOf(conf)
 	if value.Kind() != reflect.Ptr {
 		return errors.New("envconfig: value is not a pointer")
@@ -28,9 +32,9 @@ func Init(conf interface{}) error {
 	switch elem.Kind() {
 	case reflect.Ptr:
 		elem.Set(reflect.New(elem.Type().Elem()))
-		return readStruct(elem.Elem(), "", false)
+		return readStruct(elem.Elem(), prefix, false)
 	case reflect.Struct:
-		return readStruct(elem, "", false)
+		return readStruct(elem, prefix, false)
 	default:
 		return errors.New("envconfig: invalid value kind, only works on structs")
 	}

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -250,6 +250,19 @@ func TestParseOptionalStruct(t *testing.T) {
 	equals(t, "", conf.Master.Name)
 }
 
+func TestParsePrefixedStruct(t *testing.T) {
+	var conf struct {
+		Name string
+	}
+
+	os.Setenv("NAME", "bad")
+	os.Setenv("FOO_NAME", "good")
+
+	err := envconfig.InitWithPrefix(&conf, "FOO")
+	ok(t, err)
+	equals(t, "good", conf.Name)
+}
+
 // assert fails the test if the condition is false.
 func assert(tb testing.TB, condition bool, msg string, v ...interface{}) {
 	if !condition {


### PR DESCRIPTION
In shared environments it’s common to have prefixed keys, e.g. `MYAPP_MYSQL_HOST`. The workaround is currently to wrap our config `struct` in another with a field matching our prefix:

```go
type Conf {
    // …
}

func withTheCurrentCode() {
    var conf Conf
    envconfig.Init(&struct{ MyApp *Conf }{&conf})
    // …
}

func whenThisPRWillBeMerged() {
    var conf Conf
    envconfig.InitWithPrefix(&conf, "MYAPP")
}
```