### PR TITLE
parseDuration: return an error on bad values

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -159,7 +159,7 @@ func parseValue(v reflect.Value, str string) (err error) {
 	if !v.CanSet() {
 		return ErrUnexportedField
 	}
-	
+
 	vtype := v.Type()
 
 	// Special case for Unmarshaler
@@ -172,7 +172,7 @@ func parseValue(v reflect.Value, str string) (err error) {
 		return parseDuration(v, str)
 	}
 
-	kind := v.Type().Kind()
+	kind := vtype.Kind()
 	switch kind {
 	case reflect.Bool:
 		err = parseBoolValue(v, str)
@@ -217,7 +217,7 @@ func parseWithUnmarshaler(v reflect.Value, str string) error {
 func parseDuration(v reflect.Value, str string) error {
 	d, err := time.ParseDuration(str)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	v.SetInt(int64(d))

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -131,6 +131,17 @@ func TestDurationConfig(t *testing.T) {
 	equals(t, time.Minute*1, conf.Timeout)
 }
 
+func TestInvalidDurationConfig(t *testing.T) {
+	var conf struct {
+		Timeout time.Duration
+	}
+
+	os.Setenv("TIMEOUT", "foo")
+
+	err := envconfig.Init(&conf)
+	assert(t, err != nil, "err should not be nil")
+}
+
 func TestAllPointerConfig(t *testing.T) {
 	var conf struct {
 		Name   *string
@@ -272,9 +283,9 @@ func TestUnexportedField(t *testing.T) {
 	var conf struct {
 		name string
 	}
-	
+
 	os.Setenv("NAME", "foobar")
-	
+
 	err := envconfig.Init(&conf)
 	equals(t, envconfig.ErrUnexportedField, err)
 }


### PR DESCRIPTION
There was a typo in `parseDuration`: it returned `nil` even if `strconv.ParseDuration` returned an error. I also added a test for it.