### PR TITLE
optional bool should not throw exception if empty

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -110,6 +110,9 @@ func setField(value reflect.Value, name string, customName, optional bool) (err 
 	if err != nil {
 		return err
 	}
+	if len(str) == 0 && optional {
+		return nil
+	}
 
 	switch value.Kind() {
 	case reflect.Slice:


### PR DESCRIPTION
I have a boolean field marked as optional:

```Go
type Repo struct {
    Private bool `envconfig:"optional"
}
```

Even thought it is optional I still receive a parse error:

```
strconv.ParseBool: parsing "": invalid syntax
```

This pull request attempts to ignore and use default values for optional fields with empty strings.