### PR TITLE
ability to skip fields

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -49,6 +49,7 @@ func InitWithPrefix(conf interface{}, prefix string) error {
 type tag struct {
 	customName string
 	optional   bool
+	skip       bool
 }
 
 func parseTag(s string) *tag {
@@ -60,9 +61,12 @@ func parseTag(s string) *tag {
 	}
 
 	for _, v := range tokens {
-		if v == "optional" {
+		switch v {
+		case "-":
+			tag.skip = true
+		case "optional":
 			tag.optional = true
-		} else {
+		default:
 			tag.customName = v
 		}
 	}
@@ -82,6 +86,10 @@ func readStruct(value reflect.Value, parentName string, optional bool) (err erro
 			combinedName = tag.customName
 		} else {
 			combinedName = combineName(parentName, name)
+		}
+
+		if tag.skip {
+			continue
 		}
 
 	doRead:

--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,9 @@ func ExampleInit() {
 				Password string
 				Name     string
 			}
+			Params struct {
+				Charset string `envconfig:"-"`
+			}
 		}
 		Log struct {
 			Path   string


### PR DESCRIPTION
many encoder / decoder implementations allow you to skip fields. For example, one of my structures has a `map[string]string` field that I'd like to skip to avoid a parsing error.

this patch adds the ability to mark a field to be skipped by using the common `-` notiation:

```Go
MySQL struct {
	Host     string
	Port     int
	Database struct {
		User     string
		Password string
		Name     string
	}
	Params struct {
		Charset string `envconfig:"-"`
	}
}
```