### PR TITLE
encoding byte slice similar to json encoder

### DIFF
--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -73,6 +73,18 @@ func TestParseBoolConfig(t *testing.T) {
 	equals(t, true, conf.DoIt)
 }
 
+func TestParseBytesConfig(t *testing.T) {
+	var conf struct {
+		Data []byte
+	}
+
+	os.Setenv("DATA", "Rk9PQkFS")
+
+	err := envconfig.Init(&conf)
+	ok(t, err)
+	equals(t, []byte("FOOBAR"), conf.Data)
+}
+
 func TestParseFloatConfig(t *testing.T) {
 	var conf struct {
 		Delta  float32


### PR DESCRIPTION
Many Go encoding libraries, including the `encoding/json`, encode `[]byte` to base64:
http://golang.org/src/encoding/json/decode.go?s=19000:19540#L741

This patch modifies this package to behave in the same manner as the `encoding/json` package and expects byte arrays to be base64 encoded. I think having consistency among decoders would be nice, and it seems (to me) a base64 string is a bit easier to construct than a comma-separated slice of unit8, especially since posix environments ship with the `base64 --encode` command line utility.

This is just a proposal, of course, and I completely understand if you choose not to merge.