### PR TITLE
add optional global config value for each parse

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -21,6 +21,10 @@ var (
 	ErrNotAPointer = errors.New("envconfig: value is not a pointer")
 	// ErrInvalidValueKind is the error returned by Init and InitWithPrefix when the configuration object is not a struct.
 	ErrInvalidValueKind = errors.New("envconfig: invalid value kind, only works on structs")
+
+	// Optional determines whether to not throw errors by default for any key
+	// that is not found. Optional=true means errors will not be thrown.
+	Optional = false
 )
 
 type context struct {
@@ -342,7 +346,7 @@ func readValue(ctx *context) (string, error) {
 		return ctx.defaultVal, nil
 	}
 
-	if ctx.optional {
+	if ctx.optional || Optional {
 		return "", nil
 	}
 


### PR DESCRIPTION
Great package! this is nearly perfect for my needs. I'm hoping to negotiate a way to make not finding keys not throw errors by default. of course, can fork, but would prefer to contribute to the main line (may not be the only one). The rationale / motivation being that I basically want to just add this to parse pre-existing configs without having to add optionals in each of the config lines (which may later change to end up not being used, etc), and for many of those fields I do not care whether they exist or not. Basically, allowing the application to do any validations (we have many pre-existing with "default" rewriting already externally from this package). I think providing both in the package is super useful, I would just like to be able to opt out. :)

rationale for doing the change in this specific way is to not break the API (which is great -- stupid simple) or add more `Init`-esque functions. Of course, global config var is not ideal, but am very open to discussion of alternatives and am happy to contribute any conclusions we come to. 

client usage (if not obvious):

```go
var config Config
envconfig.Optional = true
envconfig.Init(&config)
```

thank you!