### PR TITLE
add options struct to initialization

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -30,7 +30,7 @@ Then it's just a matter of setting the environment variables when calling your b
 Layout of the conf struct
 
 Your conf struct must follow the following rules:
- - no unexported fields
+ - no unexported fields by default (can turn off with Options.AllowUnexported)
  - only supported types (no map fields for example)
 
 Naming of the keys

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -392,6 +392,9 @@ func TestUnexportedField(t *testing.T) {
 
 	err := envconfig.Init(&conf)
 	require.Equal(t, envconfig.ErrUnexportedField, err)
+
+	err = envconfig.InitWithOptions(&conf, envconfig.Options{AllowUnexported: true})
+	require.Equal(t, nil, err)
 }
 
 type sliceWithUnmarshaler []int


### PR DESCRIPTION
also slightly changes behavior such that unexported fields no longer
cause the program to panic (we skip looking for them in the environment,
as well).

Options struct allows three new options to be set on Init.

1) AllOptional will force the parse to consider each field optional by
default, rather than erroring when it comes across a non-optional field
that is empty.

2) LeaveNil will make the parse leave pointers in a nil state if no
inner fields or values are found after coming across a nil pointer.
If it does come across any non-empty values, then the behavior is to
create a new pointer and fill in that field. This works for any
arbitrary depth, all parent pointers will be created as needed, no
matter how deeply nested the non-empty value is.

3) AllowUnexported allows for unexported fields to be present inside
of the config. We will not set or look for any unexported fields, they
will simply be skipped over.

some discussion from #12 (continued here)

agree, went for the options struct and think that is a good choice. already found 3 uses for it :)

I think this is much better. I added some more options that are useful for my use case, turned off by default. Happy to add any more necessary clarification or answer questions. 

Thank you!